### PR TITLE
Update the different tabs in property panels to use icons

### DIFF
--- a/editor/app/scene/animation-panel.jsx
+++ b/editor/app/scene/animation-panel.jsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import {InfoDetailsProperties} from "./info-details-properties.jsx";
 import {AnimationProperties} from "./animation-properties.jsx";
+import {PanelToolbar} from "./panel-toolbar.jsx";
 
 export class AnimationPanel extends React.Component {
   constructor(props) {
@@ -19,14 +20,6 @@ export class AnimationPanel extends React.Component {
   render() {
     const {node} = this.props;
     const {selectedView} = this.state;
-    const infoDetailsClassNames = ["selected"]
-      .filter((_) => "info-details" === selectedView)
-      .concat(["button", "info-details"])
-      .join(" ");
-    const animationClassNames = ["selected"]
-      .filter((_) => "animation" === selectedView)
-      .concat(["button", "animation"])
-      .join(" ");
 
     let children = null;
     switch (selectedView) {
@@ -45,20 +38,12 @@ export class AnimationPanel extends React.Component {
           <div>{node.name}</div>
         </div>
         <div className="scene-node-details-body">
-          <div className="scene-node-details-toolbar">
-            <a
-              className={infoDetailsClassNames}
-              onClick={() => this.handleViewSelection("info-details")}
-            >
-              I
-            </a>
-            <a
-              className={animationClassNames}
-              onClick={() => this.handleViewSelection("animation")}
-            >
-              A
-            </a>
-          </div>
+          <PanelToolbar
+            tabs={["info-details", "animation"]}
+            onTabSelected={this.handleViewSelection}
+            selectedTab={selectedView}
+          />
+
           <div className="scene-node-details-content">{children}</div>
         </div>
       </React.Fragment>

--- a/editor/app/scene/light-details-panel.jsx
+++ b/editor/app/scene/light-details-panel.jsx
@@ -3,6 +3,7 @@ import {TransformProperties} from "./transform-properties.jsx";
 import {MaterialProperties} from "./material-properties.jsx";
 import {LightProperties} from "./light-properties.jsx";
 import {InfoDetailsProperties} from "./info-details-properties.jsx";
+import {PanelToolbar} from "./panel-toolbar.jsx";
 
 export class LightDetailsPanel extends React.Component {
   constructor(props) {
@@ -21,22 +22,6 @@ export class LightDetailsPanel extends React.Component {
   render() {
     const {node} = this.props;
     const {selectedView} = this.state;
-    const infoDetailsClassNames = ["selected"]
-      .filter((_) => "info-details" === selectedView)
-      .concat(["button", "info-details"])
-      .join(" ");
-    const transformClassNames = ["selected"]
-      .filter((_) => "transform" === selectedView)
-      .concat(["button", "transform"])
-      .join(" ");
-    const materialClassNames = ["selected"]
-      .filter((_) => "material" === selectedView)
-      .concat(["button", "material"])
-      .join(" ");
-    const lightClassNames = ["selected"]
-      .filter((_) => "light" === selectedView)
-      .concat(["button", "light"])
-      .join(" ");
 
     let children = null;
     switch (selectedView) {
@@ -61,26 +46,11 @@ export class LightDetailsPanel extends React.Component {
           <div>{node.name}</div>
         </div>
         <div className="scene-node-details-body">
-          <div className="scene-node-details-toolbar">
-            <a
-              className={infoDetailsClassNames}
-              onClick={() => this.handleViewSelection("info-details")}
-            >
-              I
-            </a>
-            <a
-              className={transformClassNames}
-              onClick={() => this.handleViewSelection("transform")}
-            >
-              T
-            </a>
-            <a className={materialClassNames} onClick={() => this.handleViewSelection("material")}>
-              M
-            </a>
-            <a className={lightClassNames} onClick={() => this.handleViewSelection("light")}>
-              L
-            </a>
-          </div>
+          <PanelToolbar
+            tabs={["info-details", "transform", "material", "light"]}
+            onTabSelected={this.handleViewSelection}
+            selectedTab={selectedView}
+          />
           <div className="scene-node-details-content">{children}</div>
         </div>
       </React.Fragment>

--- a/editor/app/scene/panel-toolbar.jsx
+++ b/editor/app/scene/panel-toolbar.jsx
@@ -1,0 +1,62 @@
+import * as React from "react";
+
+import {
+  Axes,
+  InfoEmpty,
+  Keyframes,
+  PerspectiveView,
+  SunLight,
+  Svg3DSelectFace,
+} from "iconoir-react";
+
+/**
+ * Maps the tab id to a set of properties to display.
+ * @param {Tab} tab
+ *
+ * @returns An object with the properties to display.
+ */
+function getTabDetails(tab) {
+  switch (tab) {
+    case "info-details":
+      return {icon: InfoEmpty, label: "Info & Details"};
+    case "transform":
+      return {icon: Axes, label: "Transform"};
+    case "material":
+      return {icon: Svg3DSelectFace, label: "Material"};
+    case "animation":
+      return {icon: Keyframes, label: "Animation"};
+    case "projection":
+      return {icon: PerspectiveView, label: "Projection"};
+    case "light":
+      return {icon: SunLight, label: "Light"};
+  }
+}
+
+/**
+ * The tabs to display in the details panel.
+ */
+export function PanelToolbar({tabs, selectedTab, onTabSelected}) {
+  return (
+    <div className="scene-node-details-toolbar">
+      {tabs.map((tab) => {
+        const classNames = ["selected"]
+          .filter((_) => tab === selectedTab)
+          .concat(["button", tab])
+          .join(" ");
+
+        const {icon: TabIcon, label} = getTabDetails(tab);
+
+        return (
+          <button
+            aria-label={label}
+            className={classNames}
+            onClick={() => onTabSelected(tab)}
+            key={tab}
+          >
+            <TabIcon />
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/editor/app/scene/projection-details-panel.jsx
+++ b/editor/app/scene/projection-details-panel.jsx
@@ -3,6 +3,7 @@ import {InfoDetailsProperties} from "./info-details-properties.jsx";
 import {TransformProperties} from "./transform-properties.jsx";
 import {OrthographicProjectionProperties} from "./othographic-projection-properties.jsx";
 import {PerspectiveProjectionProperties} from "./perspective-projection-properties.jsx";
+import {PanelToolbar} from "./panel-toolbar.jsx";
 
 export class ProjectionDetailsPanel extends React.Component {
   constructor(props) {
@@ -21,18 +22,6 @@ export class ProjectionDetailsPanel extends React.Component {
   render() {
     const {node} = this.props;
     const {selectedView} = this.state;
-    const infoDetailsClassNames = ["selected"]
-      .filter((_) => "info-details" === selectedView)
-      .concat(["button", "info-details"])
-      .join(" ");
-    const transformClassNames = ["selected"]
-      .filter((_) => "transform" === selectedView)
-      .concat(["button", "transform"])
-      .join(" ");
-    const projectionClassNames = ["selected"]
-      .filter((_) => "projection" === selectedView)
-      .concat(["button", "projection"])
-      .join(" ");
 
     let children = null;
     switch (selectedView) {
@@ -60,26 +49,11 @@ export class ProjectionDetailsPanel extends React.Component {
           <div>{node.name}</div>
         </div>
         <div className="scene-node-details-body">
-          <div className="scene-node-details-toolbar">
-            <a
-              className={infoDetailsClassNames}
-              onClick={() => this.handleViewSelection("info-details")}
-            >
-              I
-            </a>
-            <a
-              className={projectionClassNames}
-              onClick={() => this.handleViewSelection("projection")}
-            >
-              P
-            </a>
-            <a
-              className={transformClassNames}
-              onClick={() => this.handleViewSelection("transform")}
-            >
-              T
-            </a>
-          </div>
+          <PanelToolbar
+            tabs={["info-details", "projection", "transform"]}
+            onTabSelected={this.handleViewSelection}
+            selectedTab={selectedView}
+          />
           <div className="scene-node-details-content">{children}</div>
         </div>
       </React.Fragment>

--- a/editor/app/scene/skinned-mesh-details-panel.jsx
+++ b/editor/app/scene/skinned-mesh-details-panel.jsx
@@ -3,6 +3,7 @@ import {TransformProperties} from "./transform-properties.jsx";
 import {MaterialProperties} from "./material-properties.jsx";
 import {InfoDetailsProperties} from "./info-details-properties.jsx";
 import {AnimationProperties} from "./animation-properties.jsx";
+import {PanelToolbar} from "./panel-toolbar.jsx";
 
 export class SkinnedMeshDetailsPanel extends React.Component {
   constructor(props) {
@@ -21,22 +22,6 @@ export class SkinnedMeshDetailsPanel extends React.Component {
   render() {
     const {node} = this.props;
     const {selectedView} = this.state;
-    const infoDetailsClassNames = ["selected"]
-      .filter((_) => "info-details" === selectedView)
-      .concat(["button", "info-details"])
-      .join(" ");
-    const transformClassNames = ["selected"]
-      .filter((_) => "transform" === selectedView)
-      .concat(["button", "transform"])
-      .join(" ");
-    const materialClassNames = ["selected"]
-      .filter((_) => "material" === selectedView)
-      .concat(["button", "material"])
-      .join(" ");
-    const animationClassNames = ["selected"]
-      .filter((_) => "animation" === selectedView)
-      .concat(["button", "animation"])
-      .join(" ");
 
     const hasAnimation = node.animation && node.animation.type === "animation";
     let children = null;
@@ -64,31 +49,11 @@ export class SkinnedMeshDetailsPanel extends React.Component {
           <div>{node.name}</div>
         </div>
         <div className="scene-node-details-body">
-          <div className="scene-node-details-toolbar">
-            <a
-              className={infoDetailsClassNames}
-              onClick={() => this.handleViewSelection("info-details")}
-            >
-              I
-            </a>
-            <a
-              className={transformClassNames}
-              onClick={() => this.handleViewSelection("transform")}
-            >
-              T
-            </a>
-            <a className={materialClassNames} onClick={() => this.handleViewSelection("material")}>
-              M
-            </a>
-            {hasAnimation ? (
-              <a
-                className={animationClassNames}
-                onClick={() => this.handleViewSelection("animation")}
-              >
-                A
-              </a>
-            ) : null}
-          </div>
+          <PanelToolbar
+            tabs={["info-details", "transform", "material", hasAnimation ? "animation" : null]}
+            onTabSelected={this.handleViewSelection}
+            selectedTab={selectedView}
+          />
           <div className="scene-node-details-content">{children}</div>
         </div>
       </React.Fragment>

--- a/editor/app/scene/static-mesh-details-panel.jsx
+++ b/editor/app/scene/static-mesh-details-panel.jsx
@@ -3,6 +3,7 @@ import {TransformProperties} from "./transform-properties.jsx";
 import {MaterialProperties} from "./material-properties.jsx";
 import {InfoDetailsProperties} from "./info-details-properties.jsx";
 import {AnimationProperties} from "./animation-properties.jsx";
+import {PanelToolbar} from "./panel-toolbar.jsx";
 
 export class StaticMeshDetailsPanel extends React.Component {
   constructor(props) {
@@ -21,18 +22,6 @@ export class StaticMeshDetailsPanel extends React.Component {
   render() {
     const {node} = this.props;
     const {selectedView} = this.state;
-    const infoDetailsClassNames = ["selected"]
-      .filter((_) => "info-details" === selectedView)
-      .concat(["button", "info-details"])
-      .join(" ");
-    const transformClassNames = ["selected"]
-      .filter((_) => "transform" === selectedView)
-      .concat(["button", "transform"])
-      .join(" ");
-    const materialClassNames = ["selected"]
-      .filter((_) => "material" === selectedView)
-      .concat(["button", "material"])
-      .join(" ");
 
     let children = null;
     switch (selectedView) {
@@ -54,23 +43,11 @@ export class StaticMeshDetailsPanel extends React.Component {
           <div>{node.name}</div>
         </div>
         <div className="scene-node-details-body">
-          <div className="scene-node-details-toolbar">
-            <a
-              className={infoDetailsClassNames}
-              onClick={() => this.handleViewSelection("info-details")}
-            >
-              I
-            </a>
-            <a
-              className={transformClassNames}
-              onClick={() => this.handleViewSelection("transform")}
-            >
-              T
-            </a>
-            <a className={materialClassNames} onClick={() => this.handleViewSelection("material")}>
-              M
-            </a>
-          </div>
+          <PanelToolbar
+            tabs={["info-details", "transform", "material"]}
+            onTabSelected={this.handleViewSelection}
+            selectedTab={selectedView}
+          />
           <div className="scene-node-details-content">{children}</div>
         </div>
       </React.Fragment>

--- a/editor/app/scene/transform-details-panel.jsx
+++ b/editor/app/scene/transform-details-panel.jsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import {TransformProperties} from "./transform-properties.jsx";
 import {InfoDetailsProperties} from "./info-details-properties.jsx";
+import {PanelToolbar} from "./panel-toolbar.jsx";
 
 export class TransformDetailsPanel extends React.Component {
   constructor(props) {
@@ -19,14 +20,6 @@ export class TransformDetailsPanel extends React.Component {
   render() {
     const {node} = this.props;
     const {selectedView} = this.state;
-    const infoDetailsClassNames = ["selected"]
-      .filter((_) => "info-details" === selectedView)
-      .concat(["button", "info-details"])
-      .join(" ");
-    const transformClassNames = ["selected"]
-      .filter((_) => "transform" === selectedView)
-      .concat(["button", "transform"])
-      .join(" ");
 
     let children = null;
     switch (selectedView) {
@@ -45,20 +38,11 @@ export class TransformDetailsPanel extends React.Component {
           <div>{node.name}</div>
         </div>
         <div className="scene-node-details-body">
-          <div className="scene-node-details-toolbar">
-            <a
-              className={infoDetailsClassNames}
-              onClick={() => this.handleViewSelection("info-details")}
-            >
-              I
-            </a>
-            <a
-              className={transformClassNames}
-              onClick={() => this.handleViewSelection("transform")}
-            >
-              T
-            </a>
-          </div>
+          <PanelToolbar
+            tabs={["info-details", "transform"]}
+            onTabSelected={this.handleViewSelection}
+            selectedTab={selectedView}
+          />
           <div className="scene-node-details-content">{children}</div>
         </div>
       </React.Fragment>

--- a/editor/index.css
+++ b/editor/index.css
@@ -262,14 +262,19 @@ body {
 }
 
 .scene-node-details-toolbar > .button {
-  padding: 1em;
   background: #000000;
-  /* border-top: solid 1px #444444;
-  border-right: solid 1px #444444; */
+  border: none;
+  color: #fff;
+  cursor: pointer;
+  box-sizing: border-box;
+  height: 40px;
+  display: flex;
+  justify-content: center;
+  align-content: center;
+  align-items: center;
 }
 
 .scene-node-details-toolbar > .button:hover {
-  cursor: pointer;
   background: #444444;
 }
 


### PR DESCRIPTION
- Created `PanelToolbar` component to abstract out the toolbar/tabs into a separate component.
- Included iconoir icons for each tab.
- Replaced `a` with `button` and updated styles to match what we had with `a`.
- Replaced existing toolbar instances with the new `PanelToolbar` component.

<img width="386" alt="Screen Shot 2022-04-26 at 4 54 28 PM" src="https://user-images.githubusercontent.com/843075/165392391-aa7357e2-db61-4107-82f8-65a2a56c8d58.png">

<img width="417" alt="Screen Shot 2022-04-26 at 4 53 57 PM" src="https://user-images.githubusercontent.com/843075/165392407-a1e1acf7-200f-4a7a-b2af-322696bb86b8.png">

<img width="393" alt="Screen Shot 2022-04-26 at 5 06 50 PM" src="https://user-images.githubusercontent.com/843075/165392486-f52204c8-ad93-4f97-a94f-552a9b3bea55.png">

Closes #2 