### PR TITLE
refactored logic so that mesh render can be called by any node

### DIFF
--- a/src/scene/mesh.js
+++ b/src/scene/mesh.js
@@ -3,21 +3,20 @@ import {findParentItemsWithItemTypeName} from "./traversal.js";
 import * as vec3 from "../math/vector3.js";
 
 export class Mesh extends Renderable {
-  render(context) {
-    const {shaderProgram, worldMatrix, vertexBuffers} = this;
+  static render(context, node) {
+    const {shaderProgram, worldMatrix, vertexBuffers} = node;
 
     if (!vertexBuffers.length || !shaderProgram) {
       return;
     }
 
     const {sceneManager} = context;
-    const projectionMatrix = this.getProjectionMatrix();
+    const projectionMatrix = node.getProjectionMatrix();
 
     // State of the thing we are rendering.
-    const renderableState = sceneManager.getNodeStateByID(this.id);
-    let bumpLightingEnabled = renderableState.material?.bumpLighting === true;
+    const renderableState = sceneManager.getNodeStateByID(node.id);
 
-    const lightsStates = findParentItemsWithItemTypeName(this, "light").map(({id}) =>
+    const lightsStates = findParentItemsWithItemTypeName(node, "light").map(({id}) =>
       sceneManager.getNodeStateByID(id)
     );
 
@@ -53,12 +52,6 @@ export class Mesh extends Renderable {
         update: (gl, {index}) => {
           const {color = [0, 0, 0]} = (renderableState && renderableState.ambient) || {};
           gl.uniform3fv(index, color);
-        },
-      },
-      {
-        name: "bumpLighting",
-        update: (gl, {index}) => {
-          gl.uniform1i(index, bumpLightingEnabled);
         },
       },
     ];

--- a/src/scene/skinned-mesh.js
+++ b/src/scene/skinned-mesh.js
@@ -20,4 +20,8 @@ export class SkinnedMesh extends Mesh {
     super.add(node);
     return this;
   }
+
+  render(context) {
+    Mesh.render(context, this);
+  }
 }

--- a/src/scene/static-mesh.js
+++ b/src/scene/static-mesh.js
@@ -8,4 +8,8 @@ export class StaticMesh extends Mesh {
   constructor(options) {
     super({...options, type: "static-mesh"});
   }
+
+  render(context) {
+    Mesh.render(context, this);
+  }
 }


### PR DESCRIPTION
previously the `Mesh` class defined a member render function that inheritors of the mesh class called to render mesh data. But I started to run into some limitations beucase a scene node that needed to be animated also needed to inherit from Animatable. So i changed the Mesh render function a static function so that it can be called without inheriting.  This provides a much cleaner separation of concerns too because previously several classes that were not mesh inherited from mesh for convenience to access the renderable interface.