### PR TITLE
Removing default material data in scene-factory

### DIFF
--- a/editor/app/node-details-panel.jsx
+++ b/editor/app/node-details-panel.jsx
@@ -5,6 +5,7 @@ import {SkinnedMeshDetailsPanel} from "./scene/skinned-mesh-details-panel.jsx";
 import {LightDetailsPanel} from "./scene/light-details-panel.jsx";
 import {TransformDetailsPanel} from "./scene/transform-details-panel.jsx";
 import {ProjectionDetailsPanel} from "./scene/projection-details-panel.jsx";
+import {MaterialDetailsPanel} from "./scene/material-details-panel.jsx";
 
 export class NodeDetailsPanel extends React.Component {
   render() {
@@ -34,6 +35,9 @@ export class NodeDetailsPanel extends React.Component {
         break;
       case "animation":
         children = <AnimationPanel node={node} />;
+        break;
+      case "material":
+        children = <MaterialDetailsPanel node={node}/>;
         break;
       default:
         return null;

--- a/editor/app/scene/material-details-panel.jsx
+++ b/editor/app/scene/material-details-panel.jsx
@@ -1,0 +1,54 @@
+import * as React from "react";
+import {PanelToolbar} from "./panel-toolbar.jsx";
+import {InfoDetailsProperties} from "./info-details-properties.jsx";
+import {MaterialProperties} from "./material-properties.jsx";
+
+export class MaterialDetailsPanel extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      selectedView: "info-details",
+    };
+  }
+
+  handleViewSelection = (selectedView) => {
+    this.setState({
+      selectedView,
+    });
+  };
+
+  render() {
+    const {node} = this.props;
+    const {selectedView} = this.state;
+
+    let children = null;
+    switch (selectedView) {
+      case "info-details":
+        children = <InfoDetailsProperties node={node} />;
+        break;
+      case "material": {
+        children = <MaterialProperties node={node} />;
+        break;
+      }
+      default:
+        return null;
+    }
+
+    return (
+      <React.Fragment>
+        <div className="scene-node-details-header">
+          <div>{selectedView}</div>
+          <div>{node.name}</div>
+        </div>
+        <div className="scene-node-details-body">
+          <PanelToolbar
+            tabs={["info-details", "material"]}
+            onTabSelected={this.handleViewSelection}
+            selectedTab={selectedView}
+          />
+          <div className="scene-node-details-content">{children}</div>
+        </div>
+      </React.Fragment>
+    );
+  }
+}

--- a/editor/app/scene/material-properties.jsx
+++ b/editor/app/scene/material-properties.jsx
@@ -35,13 +35,17 @@ export class MaterialProperties extends WithNodeState {
 
   render() {
     const {material} = this.getNodeState();
+    if (!material) {
+      return null;
+    }
 
     return (
       <div className="node-properties material">
-        <div className="color">
-          <label>Color</label>
-          <ColorChannels onChange={this.handleChangeColor} data={material.color} />
-        </div>
+        {material.color != null ?
+          <div className="color">
+            <label>Color</label>
+            <ColorChannels onChange={this.handleChangeColor} data={material.color} />
+          </div> : null}
         <div className="reflectiveness">
           <label>Reflect</label>
           <input

--- a/editor/app/scene/material-properties.jsx
+++ b/editor/app/scene/material-properties.jsx
@@ -22,6 +22,17 @@ export class MaterialProperties extends WithNodeState {
     });
   };
 
+  handleChangeAmbientColor = (value) => {
+    const nodeState = this.getNodeState();
+    this.updateNodeState({
+      ...nodeState,
+      ambient: {
+        ...nodeState.ambient,
+        color: [...value],
+      },
+    });
+  }
+
   handleChangeReflectiveness = (evt) => {
     const nodeState = this.getNodeState();
     this.updateNodeState({
@@ -34,29 +45,35 @@ export class MaterialProperties extends WithNodeState {
   };
 
   render() {
-    const {material} = this.getNodeState();
-    if (!material) {
+    const {material, ambient} = this.getNodeState();
+    if (!material && !ambient) {
       return null;
     }
 
     return (
       <div className="node-properties material">
-        {material.color != null ?
+        {material?.color != null ?
           <div className="color">
             <label>Color</label>
             <ColorChannels onChange={this.handleChangeColor} data={material.color} />
           </div> : null}
-        <div className="reflectiveness">
-          <label>Reflect</label>
-          <input
-            type="number"
-            step=".1"
-            min="0"
-            max="1"
-            onChange={this.handleChangeReflectiveness}
-            value={material.reflectiveness}
-          />
-        </div>
+        {material?.reflectiveness != null ?
+          <div className="reflectiveness">
+            <label>Reflectiveness</label>
+            <input
+              type="number"
+              step=".1"
+              min="0"
+              max="1"
+              onChange={this.handleChangeReflectiveness}
+              value={material.reflectiveness}
+            />
+          </div> : null}
+        {ambient?.color != null ?
+          <div className="color">
+          <label>Ambient Color</label>
+          <ColorChannels onChange={this.handleChangeAmbientColor} data={ambient.color} />
+        </div> : null}
       </div>
     );
   }

--- a/editor/loaders/fbx/loader.js
+++ b/editor/loaders/fbx/loader.js
@@ -159,6 +159,9 @@ export function buildSceneNode(gl, fbxDocument, sceneNode, sceneManager) {
     });
   }
 
+  // If a model has materials, then we want to create state for them.
+  initMaterialsState(sceneNode, sceneManager);
+
   // Armature is basically the root bone of a skeleton in a rigged animation.
   // We want to make sure we have one in the scene node if there is skeletal
   // animation and there is no armature.
@@ -846,6 +849,20 @@ function buildArmature(sceneNode) {
       return 0;
     });
   }
+}
+
+function initMaterialsState(sceneNode, sceneManager) {
+  findChildrenByType(sceneNode, MaterialSceneNode).forEach((material) => {
+    sceneManager.updateNodeStateByID(material.id, {
+      material: {
+        reflectiveness: material.reflectionFactor,
+        color: material.materialColor,
+      },
+      ambient: {
+        color: material.ambientColor,
+      },
+    });
+  });
 }
 
 function initShaderProgramsForMeshes(gl, sceneNode) {

--- a/editor/scene-factory.js
+++ b/editor/scene-factory.js
@@ -81,16 +81,6 @@ export function buildDefaultState(config) {
       },
     };
 
-    if (isStaticMesh(nodeConfig) || isSkinnedMesh(nodeConfig)) {
-      Object.assign(defaults, {
-        material: {
-          color: [1, 1, 1, 1],
-          reflectiveness: 1,
-          ...nodeConfig.material,
-        },
-      });
-    }
-
     return {
       id: nodeConfig.name,
       ...nodeConfig,

--- a/editor/scenes/armatured-cube-simple.json
+++ b/editor/scenes/armatured-cube-simple.json
@@ -134,6 +134,9 @@
               "type": "skinned-mesh",
               "resource": "/resources/fbx/__testdata__/cubearmature_simple.fbx",
               "normalSmoothing": false,
+              "material": {
+                "reflectiveness": 1
+              },
               "animation": {
                 "speed": 1,
                 "fps": 24

--- a/editor/scenes/armatured-cube.json
+++ b/editor/scenes/armatured-cube.json
@@ -134,6 +134,9 @@
               "type": "skinned-mesh",
               "resource": "/resources/fbx/__testdata__/cubearmature.fbx",
               "normalSmoothing": false,
+              "material": {
+                "reflectiveness": 1
+              },
               "animation": {
                 "speed": 1,
                 "fps": 24

--- a/editor/scenes/bump-lighting-sphere.json
+++ b/editor/scenes/bump-lighting-sphere.json
@@ -143,7 +143,6 @@
                 "fps": 24
               },
               "material": {
-                "color": [1, 1, 1, 1],
                 "reflectiveness": 1,
                 "bumpLighting": true
               },

--- a/editor/scenes/jedi-star-fighter.json
+++ b/editor/scenes/jedi-star-fighter.json
@@ -143,7 +143,6 @@
                 "fps": 24
               },
               "material": {
-                "color": [1, 1, 1, 1],
                 "reflectiveness": 1,
                 "bumpLighting": true
               },

--- a/editor/scenes/skinning-mesh-animation-dancing-character.json
+++ b/editor/scenes/skinning-mesh-animation-dancing-character.json
@@ -143,9 +143,7 @@
                 "fps": 24
               },
               "material": {
-                "color": [1, 1, 1, 1],
-                "reflectiveness": 1,
-                "bumpLighting": true
+                "reflectiveness": 1
               },
               "transform": {
                 "scale": [1, 1, 1],

--- a/src/scene/material.js
+++ b/src/scene/material.js
@@ -34,6 +34,23 @@ export class Material extends Node {
     return this;
   }
 
+  preRender(context) {
+    super.preRender(context);
+
+    const state = context.sceneManager.getNodeStateByID(this.id);
+    if (state) {
+      if (state.material?.color) {
+        this.withMaterialColor(state.material.color);
+      }
+      if (state.material?.reflectiveness != null) {
+        this.withReflectionFactor(state.material?.reflectiveness);
+      }
+      if (state.ambient?.color) {
+        this.withAmbientColor(state.ambient.color);
+      }
+    }
+  }
+
   render() {
     const renderable = findParentByType(this, Renderable);
 

--- a/src/scene/mesh.js
+++ b/src/scene/mesh.js
@@ -89,36 +89,51 @@ export class Mesh extends Renderable {
     shaderProgram.addUniforms(uniforms);
   }
 
-  static configureMaterial(shaderProgram, material = {}, ambient = {}) {
-    const uniforms = [
-      {
-        name: "bumpLighting",
-        update: (gl, {index}) => {
-          gl.uniform1i(index, !!material.bumpLighting);
-        },
-      },
-      {
-        name: "materialColor",
-        update: (gl, {index}) => {
-          gl.uniform4fv(index, material.color || [1, 1, 1, 1]);
-        },
-      },
-      {
-        name: "materialReflectiveness",
-        update: (gl, {index}) => {
-          gl.uniform1f(index, material.reflectiveness == null ? 1 : material.reflectiveness);
-        },
-      },
-      {
-        name: "ambientColor",
-        update: (gl, {index}) => {
-          const color = ambient.color || [0, 0, 0];
-          gl.uniform3fv(index, color);
-        },
-      },
-    ];
+  static configureMaterial(shaderProgram, material, ambient) {
+    const uniforms = [];
 
-    shaderProgram.addUniforms(uniforms);
+    if (material) {
+      if (material.bumpLighting != null) {
+        uniforms.push({
+          name: "bumpLighting",
+          update: (gl, {index}) => {
+            gl.uniform1i(index, !!material.bumpLighting);
+          },
+        });
+      }
+      if (material.reflectiveness != null) {
+        uniforms.push({
+          name: "materialReflectiveness",
+          update: (gl, {index}) => {
+            gl.uniform1f(index, material.reflectiveness == null ? 1 : material.reflectiveness);
+          },
+        });
+      }
+      if (material.color != null) {
+        uniforms.push({
+          name: "materialColor",
+          update: (gl, {index}) => {
+            gl.uniform4fv(index, material.color || [1, 1, 1, 1]);
+          },
+        });
+      }
+    }
+
+    if (ambient) {
+      if (ambient.color != null) {
+        uniforms.push({
+          name: "ambientColor",
+          update: (gl, {index}) => {
+            const color = ambient.color || [0, 0, 0];
+            gl.uniform3fv(index, color);
+          },
+        });
+      }
+    }
+
+    if (uniforms.length) {
+      shaderProgram.addUniforms(uniforms);
+    }
   }
 
   static render(node) {


### PR DESCRIPTION
Context around the use of "mesh" here. In a scene configuration you can speficy a `skinned-mesh` or `static-mesh` so that the scene factory knows that is needs to create such node. Those nodes can be configured with a file resource such as an FBX file and in those cases the `skinned-mesh` or `static-mesh` becomes more of document node for the FBX file. FBX files _can_ multiple mesh nodes in them and they all can specify material information.

Often `skinned-mesh` and `static-mesh` are just geometry data with no material information, so I had added logic to initialize every `skinned-mesh` and `static-mesh` defined in a scene configuration with material information. That was to make things convenient when models didn't provide color information and it enabled users to change the material color in the editor. However, having a default material value in those nodes causes friction with FBX files where a single model can have multiple meshes with separate materials, all of which ended up getting overriden by default material color values we were adding.

So Im removing that logic for setting those default values and instead leaving it to the author of the scene configuration to specify a material color whenever that is needed. And in those cases where a mesh is configured in the scene configuration to have a color, I will show the material tab with the color selector so that you users can still have access to that.  And in a follow up change I am adding a material details panel so that you can select material nodes for meshes in FBX files to adjust the color of material nodes for any mesh that has them.

A TODO here would be to have the ability to override colors via the editor in `skinned-mesh` and `static-mesh` that no longer are getting a default value. But this isn't quite urgent, so we can circle back separately.