### PR TITLE
Adding Material Details panel for material nodes in the scene editor

### DIFF
--- a/editor/app/node-details-panel.jsx
+++ b/editor/app/node-details-panel.jsx
@@ -5,6 +5,7 @@ import {SkinnedMeshDetailsPanel} from "./scene/skinned-mesh-details-panel.jsx";
 import {LightDetailsPanel} from "./scene/light-details-panel.jsx";
 import {TransformDetailsPanel} from "./scene/transform-details-panel.jsx";
 import {ProjectionDetailsPanel} from "./scene/projection-details-panel.jsx";
+import {MaterialDetailsPanel} from "./scene/material-details-panel.jsx";
 
 export class NodeDetailsPanel extends React.Component {
   render() {
@@ -34,6 +35,9 @@ export class NodeDetailsPanel extends React.Component {
         break;
       case "animation":
         children = <AnimationPanel node={node} />;
+        break;
+      case "material":
+        children = <MaterialDetailsPanel node={node}/>;
         break;
       default:
         return null;

--- a/editor/app/scene/material-details-panel.jsx
+++ b/editor/app/scene/material-details-panel.jsx
@@ -1,0 +1,54 @@
+import * as React from "react";
+import {PanelToolbar} from "./panel-toolbar.jsx";
+import {InfoDetailsProperties} from "./info-details-properties.jsx";
+import {MaterialProperties} from "./material-properties.jsx";
+
+export class MaterialDetailsPanel extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      selectedView: "info-details",
+    };
+  }
+
+  handleViewSelection = (selectedView) => {
+    this.setState({
+      selectedView,
+    });
+  };
+
+  render() {
+    const {node} = this.props;
+    const {selectedView} = this.state;
+
+    let children = null;
+    switch (selectedView) {
+      case "info-details":
+        children = <InfoDetailsProperties node={node} />;
+        break;
+      case "material": {
+        children = <MaterialProperties node={node} />;
+        break;
+      }
+      default:
+        return null;
+    }
+
+    return (
+      <React.Fragment>
+        <div className="scene-node-details-header">
+          <div>{selectedView}</div>
+          <div>{node.name}</div>
+        </div>
+        <div className="scene-node-details-body">
+          <PanelToolbar
+            tabs={["info-details", "material"]}
+            onTabSelected={this.handleViewSelection}
+            selectedTab={selectedView}
+          />
+          <div className="scene-node-details-content">{children}</div>
+        </div>
+      </React.Fragment>
+    );
+  }
+}

--- a/editor/app/scene/material-properties.jsx
+++ b/editor/app/scene/material-properties.jsx
@@ -22,6 +22,17 @@ export class MaterialProperties extends WithNodeState {
     });
   };
 
+  handleChangeAmbientColor = (value) => {
+    const nodeState = this.getNodeState();
+    this.updateNodeState({
+      ...nodeState,
+      ambient: {
+        ...nodeState.ambient,
+        color: [...value],
+      },
+    });
+  }
+
   handleChangeReflectiveness = (evt) => {
     const nodeState = this.getNodeState();
     this.updateNodeState({
@@ -34,29 +45,35 @@ export class MaterialProperties extends WithNodeState {
   };
 
   render() {
-    const {material} = this.getNodeState();
-    if (!material) {
+    const {material, ambient} = this.getNodeState();
+    if (!material && !ambient) {
       return null;
     }
 
     return (
       <div className="node-properties material">
-        {material.color != null ?
+        {material?.color != null ?
           <div className="color">
             <label>Color</label>
             <ColorChannels onChange={this.handleChangeColor} data={material.color} />
           </div> : null}
-        <div className="reflectiveness">
-          <label>Reflect</label>
-          <input
-            type="number"
-            step=".1"
-            min="0"
-            max="1"
-            onChange={this.handleChangeReflectiveness}
-            value={material.reflectiveness}
-          />
-        </div>
+        {material?.reflectiveness != null ?
+          <div className="reflectiveness">
+            <label>Reflectiveness</label>
+            <input
+              type="number"
+              step=".1"
+              min="0"
+              max="1"
+              onChange={this.handleChangeReflectiveness}
+              value={material.reflectiveness}
+            />
+          </div> : null}
+        {ambient?.color != null ?
+          <div className="color">
+          <label>Ambient Color</label>
+          <ColorChannels onChange={this.handleChangeAmbientColor} data={ambient.color} />
+        </div> : null}
       </div>
     );
   }

--- a/editor/loaders/fbx/loader.js
+++ b/editor/loaders/fbx/loader.js
@@ -159,6 +159,9 @@ export function buildSceneNode(gl, fbxDocument, sceneNode, sceneManager) {
     });
   }
 
+  // If a model has materials, then we want to create state for them.
+  initMaterialsState(sceneNode, sceneManager);
+
   // Armature is basically the root bone of a skeleton in a rigged animation.
   // We want to make sure we have one in the scene node if there is skeletal
   // animation and there is no armature.
@@ -846,6 +849,20 @@ function buildArmature(sceneNode) {
       return 0;
     });
   }
+}
+
+function initMaterialsState(sceneNode, sceneManager) {
+  findChildrenByType(sceneNode, MaterialSceneNode).forEach((material) => {
+    sceneManager.updateNodeStateByID(material.id, {
+      material: {
+        reflectiveness: material.reflectionFactor,
+        color: material.materialColor,
+      },
+      ambient: {
+        color: material.ambientColor,
+      },
+    });
+  });
 }
 
 function initShaderProgramsForMeshes(gl, sceneNode) {

--- a/editor/scenes/armatured-cube-simple.json
+++ b/editor/scenes/armatured-cube-simple.json
@@ -134,6 +134,9 @@
               "type": "skinned-mesh",
               "resource": "/resources/fbx/__testdata__/cubearmature_simple.fbx",
               "normalSmoothing": false,
+              "material": {
+                "reflectiveness": 1
+              },
               "animation": {
                 "speed": 1,
                 "fps": 24

--- a/editor/scenes/armatured-cube.json
+++ b/editor/scenes/armatured-cube.json
@@ -134,6 +134,9 @@
               "type": "skinned-mesh",
               "resource": "/resources/fbx/__testdata__/cubearmature.fbx",
               "normalSmoothing": false,
+              "material": {
+                "reflectiveness": 1
+              },
               "animation": {
                 "speed": 1,
                 "fps": 24

--- a/editor/scenes/bump-lighting-sphere.json
+++ b/editor/scenes/bump-lighting-sphere.json
@@ -143,7 +143,6 @@
                 "fps": 24
               },
               "material": {
-                "color": [1, 1, 1, 1],
                 "reflectiveness": 1,
                 "bumpLighting": true
               },

--- a/editor/scenes/jedi-star-fighter.json
+++ b/editor/scenes/jedi-star-fighter.json
@@ -143,7 +143,6 @@
                 "fps": 24
               },
               "material": {
-                "color": [1, 1, 1, 1],
                 "reflectiveness": 1,
                 "bumpLighting": true
               },

--- a/editor/scenes/skinning-mesh-animation-dancing-character.json
+++ b/editor/scenes/skinning-mesh-animation-dancing-character.json
@@ -143,9 +143,7 @@
                 "fps": 24
               },
               "material": {
-                "color": [1, 1, 1, 1],
-                "reflectiveness": 1,
-                "bumpLighting": true
+                "reflectiveness": 1
               },
               "transform": {
                 "scale": [1, 1, 1],

--- a/src/scene/material.js
+++ b/src/scene/material.js
@@ -34,6 +34,23 @@ export class Material extends Node {
     return this;
   }
 
+  preRender(context) {
+    super.preRender(context);
+
+    const state = context.sceneManager.getNodeStateByID(this.id);
+    if (state) {
+      if (state.material?.color) {
+        this.withMaterialColor(state.material.color);
+      }
+      if (state.material?.reflectiveness != null) {
+        this.withReflectionFactor(state.material?.reflectiveness);
+      }
+      if (state.ambient?.color) {
+        this.withAmbientColor(state.ambient.color);
+      }
+    }
+  }
+
   render() {
     const renderable = findParentByType(this, Renderable);
 


### PR DESCRIPTION
Im adding the ability to get at material nodes information for nodes in scene editor, which is very useful in FBX files where we can have multiple meshes with their own material nodes. You can now we can change the color, the ambient color, and the reflectiveness in a material node for any mesh that has a material node with that information.

To make this work I am initializing the state of each material node with information from FBX file. This will allow material state in each mesh to be updated via the scene editor.  One side effect of this is that meshes in an FBX file need to specify a reflective factor in their material so that each mesh is visible in a lit scene.  However, if materials for meshes in an FBX file don't specify a reflective factor you can always configure one in the `skinned-mesh` or `static-mesh` node that is hosting the FBX file.  You can see such updates in the scene configurations in this commit, which I had to do because the reflective factor in all the FBX files we have a scene for have _very_ low reflective factors.  And ambient color is black, so these models were just basically not visible when the background in the scene is also black.


<img width="1194" alt="Screen Shot 2022-04-30 at 6 52 09 PM" src="https://user-images.githubusercontent.com/1457701/166126508-1d1b32be-b54a-44e7-a12b-81472cbd13a4.png">
<img width="1207" alt="Screen Shot 2022-04-30 at 7 13 03 PM" src="https://user-images.githubusercontent.com/1457701/166126510-e4a5c9a1-57f5-4f04-9dbd-176c096cf3ab.png">