### PR TITLE
Migrated all selectedView state to hooks

### DIFF
--- a/editor/app/components/utils.js
+++ b/editor/app/components/utils.js
@@ -1,0 +1,15 @@
+export const buildStyles = (styles) => {
+  return []
+    .concat(styles)
+    .filter(Boolean)
+    .reduce((acc, style) => {
+      return {
+        ...acc,
+        ...style,
+      };
+    }, {});
+};
+
+export const buildClassNames = (className) => {
+  return [].concat(className).join(" ");
+};

--- a/editor/app/scene/animation-panel.jsx
+++ b/editor/app/scene/animation-panel.jsx
@@ -4,49 +4,36 @@ import {AnimationProperties} from "./animation-properties.jsx";
 import {PanelToolbar} from "../components/panel-toolbar.jsx";
 import {Panel, PanelHeader, PanelBody} from "../components/panel.jsx";
 
-export class AnimationPanel extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      selectedView: "animation",
-    };
+import "./scene-node-details.css";
+
+export const AnimationPanel = (props) => {
+  const [selectedView, setSelectedView] = React.useState("animation");
+  const {node} = props;
+
+  let children = null;
+  switch (selectedView) {
+    case "info-details":
+      children = <InfoDetailsProperties node={node} />;
+      break;
+    case "animation":
+      children = <AnimationProperties node={node} />;
+      break;
   }
 
-  handleViewSelection = (selectedView) => {
-    this.setState({
-      selectedView,
-    });
-  };
-
-  render() {
-    const {node} = this.props;
-    const {selectedView} = this.state;
-
-    let children = null;
-    switch (selectedView) {
-      case "info-details":
-        children = <InfoDetailsProperties node={node} />;
-        break;
-      case "animation":
-        children = <AnimationProperties node={node} />;
-        break;
-    }
-
-    return (
-      <Panel>
-        <PanelHeader className="scene-node-details-header">
-          <div>{selectedView}</div>
-          <div>{node.name}</div>
-        </PanelHeader>
-        <PanelBody>
-          <PanelToolbar
-            tabs={["info-details", "animation"]}
-            onTabSelected={this.handleViewSelection}
-            selectedTab={selectedView}
-          />
-          <div className="scene-node-details-content">{children}</div>
-        </PanelBody>
-      </Panel>
-    );
-  }
-}
+  return (
+    <Panel>
+      <PanelHeader className="scene-node-details-header">
+        <div>{selectedView}</div>
+        <div>{node.name}</div>
+      </PanelHeader>
+      <PanelBody>
+        <PanelToolbar
+          tabs={["info-details", "animation"]}
+          onTabSelected={setSelectedView}
+          selectedTab={selectedView}
+        />
+        <div className="scene-node-details-content">{children}</div>
+      </PanelBody>
+    </Panel>
+  );
+};

--- a/editor/app/scene/light-details-panel.jsx
+++ b/editor/app/scene/light-details-panel.jsx
@@ -6,55 +6,42 @@ import {InfoDetailsProperties} from "./info-details-properties.jsx";
 import {PanelToolbar} from "../components/panel-toolbar.jsx";
 import {Panel, PanelHeader, PanelBody} from "../components/panel.jsx";
 
-export class LightDetailsPanel extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      selectedView: "info-details",
-    };
+import "./scene-node-details.css";
+
+export const LightDetailsPanel = (props) => {
+  const [selectedView, setSelectedView] = React.useState("info-details");
+  const {node} = props;
+
+  let children = null;
+  switch (selectedView) {
+    case "info-details":
+      children = <InfoDetailsProperties node={node} />;
+      break;
+    case "transform":
+      children = <TransformProperties node={node} />;
+      break;
+    case "material":
+      children = <MaterialProperties node={node} />;
+      break;
+    case "light":
+      children = <LightProperties node={node} />;
+      break;
   }
 
-  handleViewSelection = (selectedView) => {
-    this.setState({
-      selectedView,
-    });
-  };
-
-  render() {
-    const {node} = this.props;
-    const {selectedView} = this.state;
-
-    let children = null;
-    switch (selectedView) {
-      case "info-details":
-        children = <InfoDetailsProperties node={node} />;
-        break;
-      case "transform":
-        children = <TransformProperties node={node} />;
-        break;
-      case "material":
-        children = <MaterialProperties node={node} />;
-        break;
-      case "light":
-        children = <LightProperties node={node} />;
-        break;
-    }
-
-    return (
-      <Panel>
-        <PanelHeader className="scene-node-details-header">
-          <div>{selectedView}</div>
-          <div>{node.name}</div>
-        </PanelHeader>
-        <PanelBody>
-          <PanelToolbar
-            tabs={["info-details", "transform", "material", "light"]}
-            onTabSelected={this.handleViewSelection}
-            selectedTab={selectedView}
-          />
-          <div className="scene-node-details-content">{children}</div>
-        </PanelBody>
-      </Panel>
-    );
-  }
-}
+  return (
+    <Panel>
+      <PanelHeader className="scene-node-details-header">
+        <div>{selectedView}</div>
+        <div>{node.name}</div>
+      </PanelHeader>
+      <PanelBody>
+        <PanelToolbar
+          tabs={["info-details", "transform", "material", "light"]}
+          onTabSelected={setSelectedView}
+          selectedTab={selectedView}
+        />
+        <div className="scene-node-details-content">{children}</div>
+      </PanelBody>
+    </Panel>
+  );
+};

--- a/editor/app/scene/material-details-panel.jsx
+++ b/editor/app/scene/material-details-panel.jsx
@@ -6,52 +6,37 @@ import {Panel, PanelHeader, PanelBody} from "../components/panel.jsx";
 
 import "./scene-node-details.css";
 
-export class MaterialDetailsPanel extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      selectedView: "info-details",
-    };
-  }
+export const MaterialDetailsPanel = (props) => {
+  const [selectedView, setSelectedView] = React.useState("info-details");
+  const {node} = props;
 
-  handleViewSelection = (selectedView) => {
-    this.setState({
-      selectedView,
-    });
-  };
-
-  render() {
-    const {node} = this.props;
-    const {selectedView} = this.state;
-
-    let children = null;
-    switch (selectedView) {
-      case "info-details":
-        children = <InfoDetailsProperties node={node} />;
-        break;
-      case "material": {
-        children = <MaterialProperties node={node} />;
-        break;
-      }
-      default:
-        return null;
+  let children = null;
+  switch (selectedView) {
+    case "info-details":
+      children = <InfoDetailsProperties node={node} />;
+      break;
+    case "material": {
+      children = <MaterialProperties node={node} />;
+      break;
     }
-
-    return (
-      <Panel>
-        <PanelHeader className="scene-node-details-header">
-          <div>{selectedView}</div>
-          <div>{node.name}</div>
-        </PanelHeader>
-        <PanelBody>
-          <PanelToolbar
-            tabs={["info-details", "material"]}
-            onTabSelected={this.handleViewSelection}
-            selectedTab={selectedView}
-          />
-          <div className="scene-node-details-content">{children}</div>
-        </PanelBody>
-      </Panel>
-    );
+    default:
+      return null;
   }
+
+  return (
+    <Panel>
+      <PanelHeader className="scene-node-details-header">
+        <div>{selectedView}</div>
+        <div>{node.name}</div>
+      </PanelHeader>
+      <PanelBody>
+        <PanelToolbar
+          tabs={["info-details", "material"]}
+          onTabSelected={setSelectedView}
+          selectedTab={selectedView}
+        />
+        <div className="scene-node-details-content">{children}</div>
+      </PanelBody>
+    </Panel>
+  );
 }

--- a/editor/app/scene/projection-details-panel.jsx
+++ b/editor/app/scene/projection-details-panel.jsx
@@ -6,58 +6,45 @@ import {PerspectiveProjectionProperties} from "./perspective-projection-properti
 import {PanelToolbar} from "../components/panel-toolbar.jsx";
 import {Panel, PanelHeader, PanelBody} from "../components/panel.jsx";
 
-export class ProjectionDetailsPanel extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      selectedView: "info-details",
-    };
+import "./scene-node-details.css";
+
+export const ProjectionDetailsPanel = (props) => {
+  const [selectedView, setSelectedView] = React.useState("info-details");
+  const {node} = props;
+
+  let children = null;
+  switch (selectedView) {
+    case "info-details":
+      children = <InfoDetailsProperties node={node} />;
+      break;
+    case "projection":
+      if (node.type === "perspective") {
+        children = <PerspectiveProjectionProperties node={node} />;
+      } else if (node.type === "orthographic") {
+        children = <OrthographicProjectionProperties node={node} />;
+      }
+      break;
+    case "orthographic":
+      break;
+    case "transform":
+      children = <TransformProperties node={node} />;
+      break;
   }
 
-  handleViewSelection = (selectedView) => {
-    this.setState({
-      selectedView,
-    });
-  };
-
-  render() {
-    const {node} = this.props;
-    const {selectedView} = this.state;
-
-    let children = null;
-    switch (selectedView) {
-      case "info-details":
-        children = <InfoDetailsProperties node={node} />;
-        break;
-      case "projection":
-        if (node.type === "perspective") {
-          children = <PerspectiveProjectionProperties node={node} />;
-        } else if (node.type === "orthographic") {
-          children = <OrthographicProjectionProperties node={node} />;
-        }
-        break;
-      case "orthographic":
-        break;
-      case "transform":
-        children = <TransformProperties node={node} />;
-        break;
-    }
-
-    return (
-      <Panel>
-        <PanelHeader className="scene-node-details-header">
-          <div>{selectedView}</div>
-          <div>{node.name}</div>
-        </PanelHeader>
-        <PanelBody>
-          <PanelToolbar
-            tabs={["info-details", "projection", "transform"]}
-            onTabSelected={this.handleViewSelection}
-            selectedTab={selectedView}
-          />
-          <div className="scene-node-details-content">{children}</div>
-        </PanelBody>
-      </Panel>
-    );
-  }
-}
+  return (
+    <Panel>
+      <PanelHeader className="scene-node-details-header">
+        <div>{selectedView}</div>
+        <div>{node.name}</div>
+      </PanelHeader>
+      <PanelBody>
+        <PanelToolbar
+          tabs={["info-details", "projection", "transform"]}
+          onTabSelected={setSelectedView}
+          selectedTab={selectedView}
+        />
+        <div className="scene-node-details-content">{children}</div>
+      </PanelBody>
+    </Panel>
+  );
+};

--- a/editor/app/scene/skinned-mesh-details-panel.jsx
+++ b/editor/app/scene/skinned-mesh-details-panel.jsx
@@ -6,58 +6,45 @@ import {AnimationProperties} from "./animation-properties.jsx";
 import {PanelToolbar} from "../components/panel-toolbar.jsx";
 import {Panel, PanelHeader, PanelBody} from "../components/panel.jsx";
 
-export class SkinnedMeshDetailsPanel extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      selectedView: "animation",
-    };
+import "./scene-node-details.css";
+
+export const SkinnedMeshDetailsPanel = (props) => {
+  const [selectedView, setSelectedView] = React.useState("animation");
+  const {node} = props;
+
+  const hasAnimation = node.animation && node.animation.type === "animation";
+  let children = null;
+  switch (selectedView) {
+    case "info-details":
+      children = <InfoDetailsProperties node={node} />;
+      break;
+    case "transform":
+      children = <TransformProperties node={node} />;
+      break;
+    case "material":
+      children = <MaterialProperties node={node} />;
+      break;
+    case "animation":
+      if (hasAnimation) {
+        children = <AnimationProperties node={node.animation} />;
+      }
+      break;
   }
 
-  handleViewSelection = (selectedView) => {
-    this.setState({
-      selectedView,
-    });
-  };
-
-  render() {
-    const {node} = this.props;
-    const {selectedView} = this.state;
-
-    const hasAnimation = node.animation && node.animation.type === "animation";
-    let children = null;
-    switch (selectedView) {
-      case "info-details":
-        children = <InfoDetailsProperties node={node} />;
-        break;
-      case "transform":
-        children = <TransformProperties node={node} />;
-        break;
-      case "material":
-        children = <MaterialProperties node={node} />;
-        break;
-      case "animation":
-        if (hasAnimation) {
-          children = <AnimationProperties node={node.animation} />;
-        }
-        break;
-    }
-
-    return (
-      <Panel>
-        <PanelHeader className="scene-node-details-header">
-          <div>{selectedView}</div>
-          <div>{node.name}</div>
-        </PanelHeader>
-        <PanelBody className="scene-node-details-body">
-          <PanelToolbar
-            tabs={["info-details", "transform", "material", hasAnimation ? "animation" : null]}
-            onTabSelected={this.handleViewSelection}
-            selectedTab={selectedView}
-          />
-          <div className="scene-node-details-content">{children}</div>
-        </PanelBody>
-      </Panel>
-    );
-  }
-}
+  return (
+    <Panel>
+      <PanelHeader className="scene-node-details-header">
+        <div>{selectedView}</div>
+        <div>{node.name}</div>
+      </PanelHeader>
+      <PanelBody className="scene-node-details-body">
+        <PanelToolbar
+          tabs={["info-details", "transform", "material", hasAnimation && "animation"]}
+          onTabSelected={setSelectedView}
+          selectedTab={selectedView}
+        />
+        <div className="scene-node-details-content">{children}</div>
+      </PanelBody>
+    </Panel>
+  );
+};

--- a/editor/app/scene/static-mesh-details-panel.jsx
+++ b/editor/app/scene/static-mesh-details-panel.jsx
@@ -5,52 +5,39 @@ import {InfoDetailsProperties} from "./info-details-properties.jsx";
 import {PanelToolbar} from "../components/panel-toolbar.jsx";
 import {Panel, PanelHeader, PanelBody} from "../components/panel.jsx";
 
-export class StaticMeshDetailsPanel extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      selectedView: "info-details",
-    };
+import "./scene-node-details.css";
+
+export const StaticMeshDetailsPanel = (props) => {
+  const [selectedView, setSelectedView] = React.useState("info-details");
+  const {node} = props;
+
+  let children = null;
+  switch (selectedView) {
+    case "info-details":
+      children = <InfoDetailsProperties node={node} />;
+      break;
+    case "transform":
+      children = <TransformProperties node={node} />;
+      break;
+    case "material":
+      children = <MaterialProperties node={node} />;
+      break;
   }
 
-  handleViewSelection = (selectedView) => {
-    this.setState({
-      selectedView,
-    });
-  };
-
-  render() {
-    const {node} = this.props;
-    const {selectedView} = this.state;
-
-    let children = null;
-    switch (selectedView) {
-      case "info-details":
-        children = <InfoDetailsProperties node={node} />;
-        break;
-      case "transform":
-        children = <TransformProperties node={node} />;
-        break;
-      case "material":
-        children = <MaterialProperties node={node} />;
-        break;
-    }
-
-    return (
-      <Panel>
-        <PanelHeader className="scene-node-details-header">
-          <div>{selectedView}</div>
-          <div>{node.name}</div>
-        </PanelHeader>
-        <PanelBody>
-          <PanelToolbar
-            tabs={["info-details", "transform", "material"]}
-            onTabSelected={this.handleViewSelection}
-            selectedTab={selectedView}
-          />
-          <div className="scene-node-details-content">{children}</div>
-        </PanelBody>
-      </Panel>
-    );
-  }
-}
+  return (
+    <Panel>
+      <PanelHeader className="scene-node-details-header">
+        <div>{selectedView}</div>
+        <div>{node.name}</div>
+      </PanelHeader>
+      <PanelBody>
+        <PanelToolbar
+          tabs={["info-details", "transform", "material"]}
+          onTabSelected={setSelectedView}
+          selectedTab={selectedView}
+        />
+        <div className="scene-node-details-content">{children}</div>
+      </PanelBody>
+    </Panel>
+  );
+};

--- a/editor/app/scene/transform-details-panel.jsx
+++ b/editor/app/scene/transform-details-panel.jsx
@@ -4,49 +4,36 @@ import {InfoDetailsProperties} from "./info-details-properties.jsx";
 import {PanelToolbar} from "../components/panel-toolbar.jsx";
 import {Panel, PanelHeader, PanelBody} from "../components/panel.jsx";
 
-export class TransformDetailsPanel extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      selectedView: "info-details",
-    };
+import "./scene-node-details.css";
+
+export const TransformDetailsPanel = (props) => {
+  const [selectedView, setSelectedView] = React.useState("info-details");
+  const {node} = props;
+
+  let children = null;
+  switch (selectedView) {
+    case "info-details":
+      children = <InfoDetailsProperties node={node} />;
+      break;
+    case "transform":
+      children = <TransformProperties node={node} />;
+      break;
   }
 
-  handleViewSelection = (selectedView) => {
-    this.setState({
-      selectedView,
-    });
-  };
-
-  render() {
-    const {node} = this.props;
-    const {selectedView} = this.state;
-
-    let children = null;
-    switch (selectedView) {
-      case "info-details":
-        children = <InfoDetailsProperties node={node} />;
-        break;
-      case "transform":
-        children = <TransformProperties node={node} />;
-        break;
-    }
-
-    return (
-      <Panel>
-        <PanelHeader className="scene-node-details-header">
-          <div>{selectedView}</div>
-          <div>{node.name}</div>
-        </PanelHeader>
-        <PanelBody className="scene-node-details-body">
-          <PanelToolbar
-            tabs={["info-details", "transform"]}
-            onTabSelected={this.handleViewSelection}
-            selectedTab={selectedView}
-          />
-          <div className="scene-node-details-content">{children}</div>
-        </PanelBody>
-      </Panel>
-    );
-  }
+  return (
+    <Panel>
+      <PanelHeader className="scene-node-details-header">
+        <div>{selectedView}</div>
+        <div>{node.name}</div>
+      </PanelHeader>
+      <PanelBody className="scene-node-details-body">
+        <PanelToolbar
+          tabs={["info-details", "transform"]}
+          onTabSelected={setSelectedView}
+          selectedTab={selectedView}
+        />
+        <div className="scene-node-details-content">{children}</div>
+      </PanelBody>
+    </Panel>
+  );
 }


### PR DESCRIPTION
The scene editor has a lot of panels with tabbed panel semantics. We kept selectedView in the component state but that had a lot of boilerplate code for setting things up.  Moving that to just using useState hook cleans things up significantly.

https://github.com/MiguelCastillo/scenic/issues/19