### PR TITLE
Doing a quick POC for importing CSS files in JSX components

### DIFF
--- a/editor/app/components/panel-toolbar.css
+++ b/editor/app/components/panel-toolbar.css
@@ -1,0 +1,22 @@
+.scene-node-details-toolbar > .button {
+  background: #000000;
+  border: none;
+  color: #fff;
+  cursor: pointer;
+  box-sizing: border-box;
+  height: 40px;
+  width: 40px;
+  display: flex;
+  justify-content: center;
+  align-content: center;
+  align-items: center;
+}
+
+.scene-node-details-toolbar > .button:hover {
+  background: #444444;
+}
+
+.scene-node-details-toolbar > .button.selected {
+  cursor: pointer;
+  background-color: #333333;
+}

--- a/editor/app/components/panel-toolbar.jsx
+++ b/editor/app/components/panel-toolbar.jsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import "./panel-toolbar.css";
 
 import {
   Axes,
@@ -40,7 +41,7 @@ export function PanelToolbar({tabs, selectedTab, onTabSelected}) {
     <div className="scene-node-details-toolbar">
       {tabs.filter(Boolean).map((tab) => {
         const classNames = ["selected"]
-          .filter((_) => tab === selectedTab)
+          .filter(() => tab === selectedTab)
           .concat(["button", tab])
           .join(" ");
 


### PR DESCRIPTION
In #16 i have added a Panel component with support for css style objects.  but the question of whether or not we should use imports was raised, which I think is a very viable path forward as well.

This use built in pakit support for importing CSS which currently doesn't support scoping styles. But Im going to work on adding that as an optin feature.  In the meantime what we have is good enough to try out css imports.