### PR TITLE
Add step prop to control input

### DIFF
--- a/editor/app/components/slider.jsx
+++ b/editor/app/components/slider.jsx
@@ -14,7 +14,7 @@ const range = (start, end) => Array.from({length: end - start + 1}, (_, i) => st
  * A custom slider component that extends the standard input range control.
  */
 export default function Slider(props) {
-  const {min, max, onChange, value} = props;
+  const {min, max, onChange, step = 1, value} = props;
 
   // Create an array of labels for the slider here so these don't have to be
   // recalculated on every render.
@@ -32,6 +32,7 @@ export default function Slider(props) {
         min={min}
         max={max}
         onChange={onChange}
+        step={step}
         value={value}
         list="speeds"
       />

--- a/editor/app/scene/animation-properties.jsx
+++ b/editor/app/scene/animation-properties.jsx
@@ -67,6 +67,7 @@ export class AnimationProperties extends WithNodeState {
             min={-1}
             max={3}
             onChange={this.handleAnimationSpeedChange}
+            step={0.001}
           />
         </div>
 


### PR DESCRIPTION
Adding the `step` prop to be able to modify the `input[type=range]` step attribute.

NOTE: The step for the labels will remain as `1` so we avoid introducing any cluttering to the labels UI.
