### PR TITLE
Added setDuration to animation Playback to cleanup the API

### DIFF
--- a/editor/loaders/fbx/scene-node.js
+++ b/editor/loaders/fbx/scene-node.js
@@ -380,12 +380,17 @@ export class AnimationStack extends SceneNode {
     this.playback = new AnimationPlayback();
   }
 
-  get duration() {
-    return this.animationLayers[0].duration;
-  }
-
   add(node) {
     this.animationLayers.push(node);
+
+    if (this.playback.duration && node.duration !== this.playback.duration) {
+      // eslint-disable-next-line
+      console.warn(
+        `animation playback duration has different values. current ${this.playback.duratin}. new ${node.duration}`
+      );
+    }
+
+    this.playback.setDuration(node.duration);
     return this;
   }
 }
@@ -470,11 +475,7 @@ function getAnimation(context, animatableNode) {
   const playback = stack.playback;
 
   const {translation, rotation, scale} = evaluateAnimation(
-    playback.elapsed(
-      context.ms,
-      stack.duration,
-      animationState.speed === 0 ? minSpeed : animationState.speed
-    ),
+    playback.elapsed(context.ms, animationState.speed === 0 ? minSpeed : animationState.speed),
     curves
   );
 
@@ -574,9 +575,5 @@ function maybeUpdatePlayback(context, animationNode) {
     }
   }
 
-  playback.updateOffset(
-    ms,
-    stack.duration,
-    animationState.speed === 0 ? minSpeed : animationState.speed
-  );
+  playback.updateOffset(ms, animationState.speed === 0 ? minSpeed : animationState.speed);
 }

--- a/src/animation/keyframe.test.js
+++ b/src/animation/keyframe.test.js
@@ -25,8 +25,8 @@ describe("animate2v", () => {
       [6, 7],
     ]);
 
-    const playback = new Playback().play();
-    const animate = (ms, speed) => animator.animate(playback.elapsed(ms, animator.duration, speed));
+    const playback = new Playback().play().setDuration(animator.duration);
+    const animate = (ms, speed) => animator.animate(playback.elapsed(ms, speed));
 
     // (6-1)*0 + 1 = 0 + 1 = 1
     // (7-2)*0 + 2 = 0 + 2 = 2
@@ -101,8 +101,8 @@ describe("animate3v", () => {
       [6, 7, 8],
     ]);
 
-    const playback = new Playback().play();
-    const animate = (ms, speed) => animator.animate(playback.elapsed(ms, animator.duration, speed));
+    const playback = new Playback().play().setDuration(animator.duration);
+    const animate = (ms, speed) => animator.animate(playback.elapsed(ms, speed));
 
     // (6-1)*0 + 1 = 0 + 1 = 1
     // (7-2)*0 + 2 = 0 + 2 = 2
@@ -176,8 +176,8 @@ describe("animate3v", () => {
     ]);
 
     const speed = -1;
-    const playback = new Playback().play();
-    const animate = (ms, speed) => animator.animate(playback.elapsed(ms, animator.duration, speed));
+    const playback = new Playback().play().setDuration(animator.duration);
+    const animate = (ms, speed) => animator.animate(playback.elapsed(ms, speed));
 
     // (6-1)*(0) + 1 = 5*(0) + 1 = 1
     // (7-2)*(0) + 2 = 6*(0) + 2 = 2
@@ -214,8 +214,8 @@ describe("animate3v", () => {
 describe("animateScalar", () => {
   it("with varying length time intervals", () => {
     const animator = new AnimateScalar([0, 1, 2, 3], [0, 2000, 5000, 10000]);
-    const playback = new Playback().play();
-    const animate = (ms, speed) => animator.animate(playback.elapsed(ms, animator.duration, speed));
+    const playback = new Playback().play().setDuration(animator.duration);
+    const animate = (ms, speed) => animator.animate(playback.elapsed(ms, speed));
 
     expect(animate(0)).toEqual(0);
     expect(animate(1000)).toEqual(0.5);
@@ -233,8 +233,8 @@ describe("animateScalar", () => {
   describe("with 4 curve points with time range of -10 to 10 seconds, iterating 1 millisecond at a time", () => {
     const animator = new AnimateScalar([0, 1, 2, 3]);
     const frameRange = range(-10, 10, 1);
-    const playback = new Playback().play();
-    const animate = (ms, speed) => animator.animate(playback.elapsed(ms, animator.duration, speed));
+    const playback = new Playback().play().setDuration(animator.duration);
+    const animate = (ms, speed) => animator.animate(playback.elapsed(ms, speed));
 
     it("speed of 1", () => {
       const speed = 1;
@@ -259,8 +259,8 @@ describe("animateScalar", () => {
     const frames = range(0, 360);
     const times = range(0, 360);
     const animator = new AnimateScalar(frames, times);
-    const playback = new Playback().play();
-    const animate = (ms, speed) => animator.animate(playback.elapsed(ms, animator.duration, speed));
+    const playback = new Playback().play().setDuration(animator.duration);
+    const animate = (ms, speed) => animator.animate(playback.elapsed(ms, speed));
 
     it("speed of 1", () => {
       const speed = 1;
@@ -356,18 +356,16 @@ describe("FBX animation curve values", () => {
 
   it("speed 1", () => {
     const speed = 1;
-    const playback = new Playback().play();
-    expect(
-      keyTimes.map((t) => animator.animate(playback.elapsed(t, animator.duration, speed)))
-    ).toEqual(frames);
+    const playback = new Playback().play().setDuration(animator.duration);
+    expect(keyTimes.map((t) => animator.animate(playback.elapsed(t, speed)))).toEqual(frames);
   });
 
   it("speed -1 (reverse)", () => {
     const speed = -1;
-    const playback = new Playback().play();
-    expect(
-      keyTimes.map((t) => animator.animate(playback.elapsed(t, animator.duration, speed)))
-    ).toEqual(frames.reverse());
+    const playback = new Playback().play().setDuration(animator.duration);
+    expect(keyTimes.map((t) => animator.animate(playback.elapsed(t, speed)))).toEqual(
+      frames.reverse()
+    );
   });
 });
 
@@ -375,9 +373,8 @@ describe("Animation with different speeds", () => {
   const times = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
   const frames = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
   const animator = new AnimateScalar(frames, times);
-  const playback = new Playback().play();
-  const animate = (ms, speed) =>
-    animator.animate(playback.elapsed(ms, animator.duration, speed), speed);
+  const playback = new Playback().play().setDuration(animator.duration);
+  const animate = (ms, speed) => animator.animate(playback.elapsed(ms, speed), speed);
 
   it("speed 1", () => {
     const speed = 1;

--- a/src/animation/playback.js
+++ b/src/animation/playback.js
@@ -68,12 +68,13 @@ export class Playback {
     this._elapsed = new Elapsed(ms);
     this.state = null;
     this.speed = 1;
+    this.duration = 0;
   }
 
-  elapsed = (ms, duration, speed) => {
+  elapsed = (ms, speed) => {
     return this.state === "play"
-      ? this._elapsed.time(ms, duration, speed)
-      : this._elapsed.time(this._elapsed._pauseMs, duration, speed);
+      ? this._elapsed.time(ms, this.duration, speed)
+      : this._elapsed.time(this._elapsed._pauseMs, this.duration, speed);
   };
 
   reset = (ms) => {
@@ -102,20 +103,18 @@ export class Playback {
     return this;
   };
 
-  updateOffset = (ms, duration, speed) => {
-    // NOTE: this is tightly coupled to the duration because the calculations
-    // of the state that store in the _elapsed timer are derrived from the
-    // provided duration.  So using updateOffset should only really be shared
-    // for animation tracks with the same duration.
-    // This behavior is a signal that playback should be initialized with a
-    // duration if updateOffset is used, but for now a note is sufficient.
+  setDuration = (duration) => {
+    this.duration = duration;
+    return this;
+  };
 
+  updateOffset = (ms, speed) => {
     if (this.speed === speed || speed == null) {
       return this;
     }
 
-    const a = this.elapsed(ms, duration, speed);
-    const b = this.elapsed(ms, duration, this.speed);
+    const a = this.elapsed(ms, speed);
+    const b = this.elapsed(ms, this.speed);
     const v = (a - b) / speed;
 
     this.skip(-v);

--- a/src/animation/playback.test.js
+++ b/src/animation/playback.test.js
@@ -140,7 +140,7 @@ describe("Pause/Play animation", () => {
   let playback = new Playback();
 
   it("pausing with time reset 0", () => {
-    playback.reset(0).play();
+    playback.reset(0).play().setDuration(Number.MAX_SAFE_INTEGER);
     expect(playback.elapsed(0)).toEqual(0);
     expect(playback.elapsed(100)).toEqual(100);
 
@@ -154,7 +154,7 @@ describe("Pause/Play animation", () => {
   });
 
   it("pausing with time reset 1", () => {
-    playback.reset(1).play();
+    playback.reset(1).play().setDuration(Number.MAX_SAFE_INTEGER);
     expect(playback.elapsed(1)).toEqual(0);
     expect(playback.elapsed(2)).toEqual(1);
 
@@ -189,39 +189,35 @@ describe("Pause/Play animation", () => {
 describe("playback speed test", () => {
   describe("updateOffset", () => {
     it("with animation paused", () => {
-      const playback = new Playback().pause(5500);
-
-      const duration = 10000;
+      const playback = new Playback().pause(5500).setDuration(10000);
       const ms = 7500;
       const speed = 1.75;
 
-      const a = playback.elapsed(ms, duration, playback.speed);
+      const a = playback.elapsed(ms, playback.speed);
       expect(a).toEqual(5500);
-      const b = playback.elapsed(ms, duration, speed);
+      const b = playback.elapsed(ms, speed);
       expect(b).toEqual(9625);
 
-      playback.updateOffset(ms, duration, speed);
+      playback.updateOffset(ms, speed);
 
-      const c = playback.elapsed(ms, duration, speed);
+      const c = playback.elapsed(ms, speed);
       expect(Math.round(c)).toEqual(5500);
       expect(Math.round(playback.elapsed(ms))).toEqual(3143);
     });
 
     it("with animation playing", () => {
-      const playback = new Playback().play(5500);
-
-      const duration = 10000;
+      const playback = new Playback().play(5500).setDuration(10000);
       const ms = 7500;
       const speed = 1.75;
 
-      const a = playback.elapsed(ms, duration, speed);
+      const a = playback.elapsed(ms, speed);
       expect(a).toEqual(3500);
-      const b = playback.elapsed(ms, duration, playback.speed);
+      const b = playback.elapsed(ms, playback.speed);
       expect(b).toEqual(2000);
 
-      playback.updateOffset(ms, duration, speed);
+      playback.updateOffset(ms, speed);
 
-      const c = playback.elapsed(ms, duration, speed);
+      const c = playback.elapsed(ms, speed);
       expect(Math.round(c)).toEqual(b);
       expect(Math.round(playback.elapsed(ms))).toEqual(1143);
     });
@@ -234,14 +230,13 @@ describe("playback speed test", () => {
     // backwards because updateOffset will make _elapsed._offset very negative
     // so all elapsed numbers come out as negative.
     it("with unstarted animation, using negative speed and then positive speed - first case", () => {
-      const playback = new Playback();
-      const duration = 10000;
+      const playback = new Playback().setDuration(10000);
 
-      playback.updateOffset(1000, duration, -1);
-      playback.updateOffset(4000, duration, 0.5);
+      playback.updateOffset(1000, -1);
+      playback.updateOffset(4000, 0.5);
       playback.play();
-      expect(playback.elapsed(7000, duration, 0.5)).toEqual(3500);
-      expect(playback.elapsed(7500, duration, 0.5)).toEqual(3750);
+      expect(playback.elapsed(7000, 0.5)).toEqual(3500);
+      expect(playback.elapsed(7500, 0.5)).toEqual(3750);
     });
 
     // This is a tricky situation that when broken causes animation to run
@@ -252,24 +247,23 @@ describe("playback speed test", () => {
     // backwards because updateOffset will make _elapsed._offset very negative
     // so all elapsed numbers come out as negative.
     it("with unstarted animation, using negative speed and then positive speed - second case", () => {
-      const playback = new Playback();
-      const duration = 10000;
+      const playback = new Playback().setDuration(10000);
 
-      playback.updateOffset(1000, duration, -0.5);
-      playback.updateOffset(4000, duration, 1);
+      playback.updateOffset(1000, -0.5);
+      playback.updateOffset(4000, 1);
       playback.play();
-      expect(playback.elapsed(7000, duration, 1)).toEqual(7000);
-      expect(playback.elapsed(7500, duration, 1)).toEqual(7500);
+      expect(playback.elapsed(7000, 1)).toEqual(7000);
+      expect(playback.elapsed(7500, 1)).toEqual(7500);
     });
   });
 
   it("with speed range or -.5 to .5 at 500 milliseconds into the animation", () => {
-    const playback = new Playback().play();
+    const playback = new Playback().play().setDuration(10000);
 
     expect(
       range(-0.5, 0.5, 0.05)
         .map((s) => {
-          return playback.elapsed(500, 10000, s);
+          return playback.elapsed(500, s);
         })
         .map(fixed5f)
     ).toEqual([
@@ -279,12 +273,12 @@ describe("playback speed test", () => {
   });
 
   it("with speed range or -.5 to .5 at 5 seconds into the animation", () => {
-    const playback = new Playback().play();
+    const playback = new Playback().play().setDuration(10000);
 
     expect(
       range(-0.5, 0.5, 0.05)
         .map((s) => {
-          return playback.elapsed(5000, 10000, s);
+          return playback.elapsed(5000, s);
         })
         .map(fixed5f)
     ).toEqual([
@@ -294,32 +288,30 @@ describe("playback speed test", () => {
   });
 
   it("with advancing time and positive speed", () => {
-    const duration = 10000;
     const speed = 1;
-    const playback = new Playback().play(5000);
+    const playback = new Playback().play(5000).setDuration(10000);
 
-    expect(playback.elapsed(0, duration, speed)).toEqual(5000);
+    expect(playback.elapsed(0, speed)).toEqual(5000);
 
     expect(
       range(6000, 7000, 100)
         .map((v) => {
-          return playback.elapsed(v, duration, speed);
+          return playback.elapsed(v, speed);
         })
         .map(fixed5f)
     ).toEqual([1000, 1100, 1200, 1300, 1400, 1500, 1600, 1700, 1800, 1900, 2000]);
   });
 
   it("with advancing time and negative speed", () => {
-    const duration = 10000;
     const speed = -1;
-    const playback = new Playback().play(5000);
+    const playback = new Playback().play(5000).setDuration(10000);
 
-    expect(playback.elapsed(0, duration, speed)).toEqual(5000);
+    expect(playback.elapsed(0, speed)).toEqual(5000);
 
     expect(
       range(7000, 8000, 100)
         .map((v) => {
-          return playback.elapsed(v, duration, speed);
+          return playback.elapsed(v, speed);
         })
         .map(fixed5f)
     ).toEqual([8000, 7900, 7800, 7700, 7600, 7500, 7400, 7300, 7200, 7100, 7000]);


### PR DESCRIPTION
Animation playback can specify a duration for the animation. This used to be provided in updateOffset and elapsed function in Playback which made things confusing beacuse calculated state relied on duration so calling updateOffset with a duration that is different than what is provided to elapsed would generate bad values. The API needing the duration is a bit noisy. So I have added a setDuration function to save that as part of the playback functionality so make things more consistent and less error prone.